### PR TITLE
Hacky fix for the token-invalidation bug

### DIFF
--- a/fs/remote/resolver.go
+++ b/fs/remote/resolver.go
@@ -271,8 +271,14 @@ func (tr *transport) RoundTrip(req *http.Request) (*http.Response, error) {
 	if resp.StatusCode == http.StatusUnauthorized {
 		log.G(ctx).Infof("Received status code: %v. Refreshing creds...", resp.Status)
 
-		// prepare authorization for the target host using docker.Authorizer
-		if err := tr.auth.AddResponses(ctx, []*http.Response{resp}); err != nil {
+		// prepare authorization for the target host using docker.Authorizer.
+		// The docker authorizer only refreshes OAuth tokens after two
+		// successive 401 errors for the same URL. Rather than issue multiple
+		// round trips for the same, just provide the same response twice to
+		// trick it into refreshing the cached OAuth token.
+		// TODO: fix after https://github.com/containerd/containerd/pull/8735
+		// is merged and released.
+		if err := tr.auth.AddResponses(ctx, []*http.Response{resp, resp}); err != nil {
 			if errdefs.IsNotImplemented(err) {
 				return resp, nil
 			}

--- a/fs/remote/resolver.go
+++ b/fs/remote/resolver.go
@@ -273,9 +273,10 @@ func (tr *transport) RoundTrip(req *http.Request) (*http.Response, error) {
 
 		// prepare authorization for the target host using docker.Authorizer.
 		// The docker authorizer only refreshes OAuth tokens after two
-		// successive 401 errors for the same URL. Rather than issue multiple
-		// round trips for the same, just provide the same response twice to
-		// trick it into refreshing the cached OAuth token.
+		// successive 401 errors for the same URL. Rather than issue the same
+		// request multiple times to tickle the token-refreshing logic, just
+		// provide the same response twice to trick it into refreshing the
+		// cached OAuth token.
 		// TODO: fix after https://github.com/containerd/containerd/pull/8735
 		// is merged and released.
 		if err := tr.auth.AddResponses(ctx, []*http.Response{resp, resp}); err != nil {

--- a/fs/remote/resolver.go
+++ b/fs/remote/resolver.go
@@ -277,7 +277,8 @@ func (tr *transport) RoundTrip(req *http.Request) (*http.Response, error) {
 		// request multiple times to tickle the token-refreshing logic, just
 		// provide the same response twice to trick it into refreshing the
 		// cached OAuth token. Call AddResponses() twice, first to invalidate
-		// the existing token, second to fetch a new one.
+		// the existing token (with two respones), second to fetch a new one (
+		// with one response).
 		// TODO: fix after https://github.com/containerd/containerd/pull/8735
 		// is merged and released.
 		if err := tr.auth.AddResponses(ctx, []*http.Response{resp, resp}); err != nil {
@@ -286,7 +287,7 @@ func (tr *transport) RoundTrip(req *http.Request) (*http.Response, error) {
 			}
 			return nil, err
 		}
-		if err := tr.auth.AddResponses(ctx, []*http.Response{resp, resp}); err != nil {
+		if err := tr.auth.AddResponses(ctx, []*http.Response{resp}); err != nil {
 			if errdefs.IsNotImplemented(err) {
 				return resp, nil
 			}


### PR DESCRIPTION
There's a fairly detailed description of the bug here: https://github.com/awslabs/soci-snapshotter/issues/686 This PR fixes it by tricking the docker authorizer into refresh cached OAuth bearer tokens after a single 401 response instead of two, because the single 401 response usually (always?) means the cached OAuth token has expired.