### PR TITLE
Add a local_keychain gRPC service that accepts and provides per-image credentials to soci-store

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /out
 *.db
+*.pb.go
 .vscode/
 /benchmark/*/output/
 /benchmark/bin/

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ FBS_FILE_PATH_COMPRESSION=$(CURDIR)/ztoc/compression/fbs/zinfo.fbs
 COMMIT=$(shell git rev-parse HEAD)
 STARGZ_BINARY?=/usr/local/bin/containerd-stargz-grpc
 
-CMD=soci-snapshotter-grpc soci soci-store
+CMD=proto soci-snapshotter-grpc soci soci-store
 
 CMD_BINARIES=$(addprefix $(OUTDIR)/,$(CMD))
 
@@ -58,8 +58,11 @@ soci-snapshotter-grpc: FORCE
 soci: FORCE
 	cd cmd/ ; GO111MODULE=$(GO111MODULE_VALUE) go build -o $(OUTDIR)/$@ $(GO_BUILD_FLAGS) $(GO_LD_FLAGS) $(GO_TAGS) ./soci
 
-soci-store: FORCE
+soci-store: proto
 	cd cmd/ ; GO111MODULE=$(GO111MODULE_VALUE) go build -o $(OUTDIR)/$@ $(GO_BUILD_FLAGS) $(GO_LD_FLAGS) ./soci-store
+
+proto: FORCE
+	protoc --go_out=. --go_opt=paths=source_relative --go-grpc_out=. --go-grpc_opt=paths=source_relative proto/local_keychain.proto
 
 check:
 	cd scripts/ ; ./check-all.sh
@@ -80,7 +83,7 @@ uninstall:
 	@rm -f $(addprefix $(CMD_DESTDIR)/bin/,$(notdir $(CMD_BINARIES)))
 
 clean:
-	rm -rf $(OUTDIR)
+	rm -rf $(OUTDIR) proto/*.pb.go
 
 vendor:
 	@GO111MODULE=$(GO111MODULE_VALUE) go mod tidy

--- a/Makefile
+++ b/Makefile
@@ -40,11 +40,11 @@ FBS_FILE_PATH_COMPRESSION=$(CURDIR)/ztoc/compression/fbs/zinfo.fbs
 COMMIT=$(shell git rev-parse HEAD)
 STARGZ_BINARY?=/usr/local/bin/containerd-stargz-grpc
 
-CMD=proto soci-snapshotter-grpc soci soci-store
+CMD=soci-store soci-snapshotter-grpc soci
 
 CMD_BINARIES=$(addprefix $(OUTDIR)/,$(CMD))
 
-.PHONY: all build check add-ltag install uninstall clean test integration
+.PHONY: all build check add-ltag install uninstall clean test integration proto
 
 all: build
 
@@ -61,7 +61,7 @@ soci: FORCE
 soci-store: proto
 	cd cmd/ ; GO111MODULE=$(GO111MODULE_VALUE) go build -o $(OUTDIR)/$@ $(GO_BUILD_FLAGS) $(GO_LD_FLAGS) ./soci-store
 
-proto: FORCE
+proto:
 	protoc --go_out=. --go_opt=paths=source_relative --go-grpc_out=. --go-grpc_opt=paths=source_relative proto/local_keychain.proto
 
 check:

--- a/cmd/soci-store/main.go
+++ b/cmd/soci-store/main.go
@@ -48,6 +48,7 @@ import (
 	"github.com/awslabs/soci-snapshotter/metadata"
 	"github.com/awslabs/soci-snapshotter/service/keychain/dockerconfig"
 	"github.com/awslabs/soci-snapshotter/service/keychain/kubeconfig"
+	"github.com/awslabs/soci-snapshotter/service/keychain/local_keychain"
 	"github.com/awslabs/soci-snapshotter/service/resolver"
 	"github.com/awslabs/soci-snapshotter/store"
 	"github.com/awslabs/soci-snapshotter/ztoc"
@@ -126,7 +127,8 @@ func main() {
 	}
 
 	// Prepare kubeconfig-based keychain if required
-	credsFuncs := []resolver.Credential{dockerconfig.NewDockerConfigKeychain(ctx)}
+	credsFuncs := []resolver.Credential{local_keychain.Keychain(ctx)}
+	credsFuncs = append(credsFuncs, dockerconfig.NewDockerConfigKeychain(ctx))
 	if config.KubeconfigKeychainConfig.EnableKeychain {
 		var opts []kubeconfig.Option
 		if kcp := config.KubeconfigKeychainConfig.KubeconfigPath; kcp != "" {

--- a/cmd/soci-store/main.go
+++ b/cmd/soci-store/main.go
@@ -127,7 +127,7 @@ func main() {
 	}
 
 	// Prepare kubeconfig-based keychain if required
-	credsFuncs := []resolver.Credential{local_keychain.Keychain(ctx)}
+	credsFuncs := []resolver.Credential{local_keychain.Keychain(ctx).GetCredentials}
 	credsFuncs = append(credsFuncs, dockerconfig.NewDockerConfigKeychain(ctx))
 	if config.KubeconfigKeychainConfig.EnableKeychain {
 		var opts []kubeconfig.Option

--- a/fs/artifact_fetcher.go
+++ b/fs/artifact_fetcher.go
@@ -27,6 +27,7 @@ import (
 
 	"github.com/awslabs/soci-snapshotter/fs/config"
 	"github.com/awslabs/soci-snapshotter/service/keychain/dockerconfig"
+	"github.com/awslabs/soci-snapshotter/service/keychain/local_keychain"
 	"github.com/awslabs/soci-snapshotter/soci"
 	socihttp "github.com/awslabs/soci-snapshotter/util/http"
 	"github.com/awslabs/soci-snapshotter/util/ioutils"
@@ -79,7 +80,14 @@ func newRemoteStore(refspec reference.Spec) (*remote.Repository, error) {
 	authClient := auth.Client{
 		Client: socihttp.NewRetryableClient(socihttp.NewRetryableClientConfig()),
 		Cache:  auth.DefaultCache,
-		Credential: func(_ context.Context, host string) (auth.Credential, error) {
+		Credential: func(ctx context.Context, host string) (auth.Credential, error) {
+			username, password, err := local_keychain.Keychain(ctx)(host, refspec)
+			if err != nil {
+				return auth.Credential{
+					Username: username,
+					Password: password,
+				}, nil
+			}
 			username, secret, err := dockerconfig.DockerCreds(host)
 			if err != nil {
 				return auth.EmptyCredential, err

--- a/fs/artifact_fetcher.go
+++ b/fs/artifact_fetcher.go
@@ -81,7 +81,7 @@ func newRemoteStore(refspec reference.Spec) (*remote.Repository, error) {
 		Client: socihttp.NewRetryableClient(socihttp.NewRetryableClientConfig()),
 		Cache:  auth.DefaultCache,
 		Credential: func(ctx context.Context, host string) (auth.Credential, error) {
-			username, password, err := local_keychain.Keychain(ctx)(host, refspec)
+			username, password, err := local_keychain.Keychain(ctx).GetCredentials(host, refspec)
 			if err != nil {
 				return auth.Credential{
 					Username: username,

--- a/fs/remote/resolver.go
+++ b/fs/remote/resolver.go
@@ -271,8 +271,14 @@ func (tr *transport) RoundTrip(req *http.Request) (*http.Response, error) {
 	if resp.StatusCode == http.StatusUnauthorized {
 		log.G(ctx).Infof("Received status code: %v. Refreshing creds...", resp.Status)
 
-		// prepare authorization for the target host using docker.Authorizer
-		if err := tr.auth.AddResponses(ctx, []*http.Response{resp}); err != nil {
+		// prepare authorization for the target host using docker.Authorizer.
+		// The docker authorizer only refreshes OAuth tokens after two
+		// successive 401 errors for the same URL. Rather than issue multiple
+		// round trips for the same, just provide the same response twice to
+		// trick it into refreshing the cached OAuth token.
+		// TODO: fix after https://github.com/containerd/containerd/pull/8735
+		// is merged and released.
+		if err := tr.auth.AddResponses(ctx, []*http.Response{resp, resp}); err != nil {
 			if errdefs.IsNotImplemented(err) {
 				return resp, nil
 			}

--- a/proto/local_keychain.proto
+++ b/proto/local_keychain.proto
@@ -1,0 +1,23 @@
+syntax = "proto3";
+
+package local_keychain;
+
+option go_package = "github.com/awslabs/soci-snapshotter/proto/";
+
+message Credentials {
+    string username = 1;
+    string password = 2;
+  }
+
+message PutCredentialsRequest {
+    string image_name = 1;
+    Credentials credentials = 2;
+    int64 expires_in_seconds = 3;
+}
+
+message PutCredentialsResponse {
+}
+
+service LocalKeychain {
+    rpc PutCredentials(PutCredentialsRequest) returns (PutCredentialsResponse);
+}

--- a/service/keychain/local_keychain/local_keychain.go
+++ b/service/keychain/local_keychain/local_keychain.go
@@ -89,6 +89,7 @@ func (kc *keychain) init() {
 
 func (kc *keychain) PutCredentials(ctx context.Context, req *proto.PutCredentialsRequest) (res *proto.PutCredentialsResponse, err error) {
 	if req.ImageName != "" && req.Credentials != nil {
+		log.G(ctx).Infof("received credentials for image %s, caching for %d seconds", req.ImageName, req.ExpiresInSeconds)
 		var expirationTime *time.Time
 		if req.ExpiresInSeconds > 0 {
 			timeout := time.Now().Add(time.Duration(req.ExpiresInSeconds) * time.Second)

--- a/service/keychain/local_keychain/local_keychain.go
+++ b/service/keychain/local_keychain/local_keychain.go
@@ -51,7 +51,7 @@ import (
 
 var (
 	localKeychainPort = flag.Int("local_keychain_port", 0,
-		"port on which to expose the local_keychain gRPC service that accepts username/password credentials for private images. ")
+		"Port on which to expose the local_keychain gRPC service that accepts username/password credentials for private images. If 0, the local_keychain service is not started/exposed.")
 )
 
 type credentials struct {

--- a/service/keychain/local_keychain/local_keychain.go
+++ b/service/keychain/local_keychain/local_keychain.go
@@ -1,0 +1,130 @@
+/*
+   Copyright The Soci Snapshotter Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+/*
+   Copyright The containerd Authors.
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+*/
+
+package local_keychain
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"net"
+	"sync"
+	"time"
+
+	"github.com/awslabs/soci-snapshotter/proto"
+	"github.com/awslabs/soci-snapshotter/service/resolver"
+	"github.com/containerd/containerd/log"
+	"github.com/containerd/containerd/reference"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/reflection"
+)
+
+var (
+	localKeychainPort = flag.Int("local_keychain_port", 0,
+		"port on which to expose the local_keychain gRPC service that accepts username/password credentials for private images. ")
+)
+
+type credentials struct {
+	username   string
+	password   string
+	expiration *time.Time
+}
+
+type keychain struct {
+	cache map[string]credentials
+	proto.UnimplementedLocalKeychainServer
+}
+
+var singleton *keychain
+var lock = &sync.Mutex{}
+
+func (kc *keychain) init() {
+	if *localKeychainPort == 0 {
+		log.G(context.Background()).Info("no local_keychain_port specified, not starting local_keychain gRPC server")
+		return
+	}
+
+	lis, err := net.Listen("tcp", fmt.Sprintf("localhost:%d", *localKeychainPort))
+	if err != nil {
+		log.G(context.Background()).Fatalf("failed to listen: %v", err)
+	} else {
+		log.G(context.Background()).Infof("started local keychain server on localhost:%d", *localKeychainPort)
+	}
+	var opts []grpc.ServerOption
+	grpcServer := grpc.NewServer(opts...)
+	proto.RegisterLocalKeychainServer(grpcServer, kc)
+	reflection.Register(grpcServer)
+	go grpcServer.Serve(lis)
+}
+
+func (kc *keychain) PutCredentials(ctx context.Context, req *proto.PutCredentialsRequest) (res *proto.PutCredentialsResponse, err error) {
+	if req.ImageName != "" && req.Credentials != nil {
+		var expirationTime *time.Time
+		if req.ExpiresInSeconds > 0 {
+			timeout := time.Now().Add(time.Duration(req.ExpiresInSeconds) * time.Second)
+			expirationTime = &timeout
+		}
+		kc.cache[req.ImageName] = credentials{
+			username:   req.Credentials.Username,
+			password:   req.Credentials.Password,
+			expiration: expirationTime,
+		}
+	}
+	return &proto.PutCredentialsResponse{}, nil
+}
+
+func (kc *keychain) getCredentials(host string, refspec reference.Spec) (string, string, error) {
+	creds, found := kc.cache[refspec.String()]
+	if found && (creds.expiration == nil || creds.expiration.After(time.Now())) {
+		return creds.username, creds.password, nil
+	} else if found {
+		// Credentials were cached but have expired, remove them.
+		delete(kc.cache, refspec.String())
+	}
+	return "", "", errors.New("credentials not found")
+}
+
+func Keychain(ctx context.Context) resolver.Credential {
+	lock.Lock()
+	defer lock.Unlock()
+	if singleton == nil {
+		singleton = &keychain{
+			cache: map[string]credentials{},
+		}
+		singleton.init()
+	}
+
+	return func(host string, refspec reference.Spec) (string, string, error) {
+		return singleton.getCredentials(host, refspec)
+	}
+}


### PR DESCRIPTION
This PR adds a little gRPC service to the soci-store that starts on startup (if a port is provided) and exports one function that accepts per-image credentials with an optional expiration. Then, the soci-store will use those credentials to pull parts of that image until they expire, instead of other configured authentication mechanisms (docker, kubernetes).

There will be a follow-up PR in the executor that sends one of these RPCs before pulling images.

Ideally one day we can get rid of this and move the soci-store stuff into the executor where it can share credentials more directly, but that is a bit more effort.