### PR TITLE
Remove trailing '/' from proto's go_package

### DIFF
--- a/proto/local_keychain.proto
+++ b/proto/local_keychain.proto
@@ -2,7 +2,7 @@ syntax = "proto3";
 
 package local_keychain;
 
-option go_package = "github.com/awslabs/soci-snapshotter/proto/";
+option go_package = "github.com/awslabs/soci-snapshotter/proto";
 
 message Credentials {
     string username = 1;


### PR DESCRIPTION
I thought this would append the name of the proto file to the package and generate something comprehensible, but it actually just uses it as-is which makes it un-importable in go because packages can't end in a '/'.