### PR TITLE
Don't return a not-found error from local_keychain when credentials are not available

### DIFF
--- a/service/keychain/local_keychain/local_keychain.go
+++ b/service/keychain/local_keychain/local_keychain.go
@@ -34,7 +34,6 @@ package local_keychain
 
 import (
 	"context"
-	"errors"
 	"flag"
 	"fmt"
 	"net"
@@ -122,7 +121,7 @@ func (kc *keychain) GetCredentials(host string, refspec reference.Spec) (string,
 		// Credentials were cached but have expired, remove them.
 		delete(kc.cache, refspec.String())
 	}
-	return "", "", errors.New("credentials not found")
+	return "", "", nil
 }
 
 func Keychain(ctx context.Context) *keychain {


### PR DESCRIPTION
The code that uses this at a higher level combines it with other credential providers and propagates this error upwards when its returned, rather than falling back to the other credential providers.