### PR TITLE
Correctly trim "sha256:" from the beginning of image manifest configs

### DIFF
--- a/fs/fs.go
+++ b/fs/fs.go
@@ -311,7 +311,7 @@ func (c *sociContext) Init(fsCtx context.Context, ctx context.Context, imageRef,
 		}
 
 		if indexDigest == "" {
-			imageManifestHash := strings.Trim(imageManifestDigest, "sha256:")
+			imageManifestHash := strings.TrimPrefix(imageManifestDigest, "sha256:")
 			log.G(ctx).Debugf("soci index digest for image %s not provided, attempting to retrieve locally/remotely", imageManifestHash)
 			index, err := os.ReadFile(filepath.Join(config.SociIndexStorePath, imageManifestHash))
 			if err == nil {


### PR DESCRIPTION
This fixes a bug we were Trim("sha256:")ing image manifest config hashes used for searching for a SOCI index on the local filesystem, which removes any occurrence of 's', 'h', 'a', '2', '5', '6', or ':' from the start or end of the provided hash. Instead, we want to TrimPrefix("sha256:") which only removes the string "sha256:" from the start of the image manifest config hash if it's there. This bug causes any images with manifest config hashes starting or ending with 'a', '2', '5', or '6' to not be streamed correctly, except for our executor images (because they'll fall back to fetching the SOCI index from the registry).