### PR TITLE
Prepare soci-store to be linked into and run by the executor

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -52,10 +52,10 @@ build: $(CMD)
 
 FORCE:
 
-soci-snapshotter-grpc: FORCE
+soci-snapshotter-grpc: proto
 	cd cmd/ ; GO111MODULE=$(GO111MODULE_VALUE) go build -o $(OUTDIR)/$@ $(GO_BUILD_FLAGS) $(GO_LD_FLAGS) $(GO_TAGS) ./soci-snapshotter-grpc
 
-soci: FORCE
+soci: proto
 	cd cmd/ ; GO111MODULE=$(GO111MODULE_VALUE) go build -o $(OUTDIR)/$@ $(GO_BUILD_FLAGS) $(GO_LD_FLAGS) $(GO_TAGS) ./soci
 
 soci-store: proto

--- a/cmd/soci-store/main.go
+++ b/cmd/soci-store/main.go
@@ -128,7 +128,7 @@ func main() {
 	}
 
 	// Prepare kubeconfig-based keychain if required
-	credsFuncs := []resolver.Credential{local_keychain.Keychain(ctx, *localKeychainPort).GetCredentials}
+	credsFuncs := []resolver.Credential{local_keychain.Init(ctx, *localKeychainPort).GetCredentials}
 	credsFuncs = append(credsFuncs, dockerconfig.NewDockerConfigKeychain(ctx))
 	if config.KubeconfigKeychainConfig.EnableKeychain {
 		var opts []kubeconfig.Option

--- a/cmd/soci/commands/create.go
+++ b/cmd/soci/commands/create.go
@@ -78,14 +78,14 @@ var CreateCommand = cli.Command{
 		// Creating the snapshotter's root path first if it does not exist, since this ensures, that
 		// it has the limited permission set as drwx--x--x.
 		// The subsequent oci.New creates a root path dir with too broad permission set.
-		if _, err := os.Stat(config.SociSnapshotterRootPath); os.IsNotExist(err) {
-			if err = os.Mkdir(config.SociSnapshotterRootPath, 0711); err != nil {
+		if _, err := os.Stat(config.DefaultSociSnapshotterRootPath); os.IsNotExist(err) {
+			if err = os.Mkdir(config.DefaultSociSnapshotterRootPath, 0711); err != nil {
 				return err
 			}
 		} else if err != nil {
 			return err
 		}
-		blobStore, err := oci.New(config.SociContentStorePath)
+		blobStore, err := oci.New(config.DefaultSociContentStorePath)
 		if err != nil {
 			return err
 		}

--- a/cmd/soci/commands/index/info.go
+++ b/cmd/soci/commands/index/info.go
@@ -52,7 +52,7 @@ var infoCommand = cli.Command{
 		if artifactType == soci.ArtifactEntryTypeLayer {
 			return fmt.Errorf("the provided digest is of ztoc not SOCI index. Use \"soci ztoc info\" command to get detailed info of ztoc")
 		}
-		storage, err := oci.New(config.SociContentStorePath)
+		storage, err := oci.New(config.DefaultSociContentStorePath)
 		if err != nil {
 			return err
 		}

--- a/cmd/soci/commands/push.go
+++ b/cmd/soci/commands/push.go
@@ -133,7 +133,7 @@ if they are available in the snapshotter's local content store.
 			}, nil
 		}
 
-		src, err := oci.New(config.SociContentStorePath)
+		src, err := oci.New(config.DefaultSociContentStorePath)
 		if err != nil {
 			return fmt.Errorf("cannot create OCI local store: %w", err)
 		}

--- a/cmd/soci/commands/rebuild_db.go
+++ b/cmd/soci/commands/rebuild_db.go
@@ -40,11 +40,11 @@ var RebuildDBCommand = cli.Command{
 		if err != nil {
 			return err
 		}
-		blobStore, err := oci.New(config.SociContentStorePath)
+		blobStore, err := oci.New(config.DefaultSociContentStorePath)
 		if err != nil {
 			return err
 		}
-		blobStorePath := filepath.Join(config.SociContentStorePath, "blobs")
+		blobStorePath := filepath.Join(config.DefaultSociContentStorePath, "blobs")
 		return artifactsDb.SyncWithLocalStore(ctx, blobStore, blobStorePath, containerdContentStore)
 	},
 }

--- a/cmd/soci/commands/ztoc/get-file.go
+++ b/cmd/soci/commands/ztoc/get-file.go
@@ -88,7 +88,7 @@ var getFileCommand = cli.Command{
 }
 
 func getZtoc(ctx context.Context, d digest.Digest) (*ztoc.Ztoc, error) {
-	blobStore, err := oci.New(config.SociContentStorePath)
+	blobStore, err := oci.New(config.DefaultSociContentStorePath)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/soci/commands/ztoc/info.go
+++ b/cmd/soci/commands/ztoc/info.go
@@ -71,7 +71,7 @@ var infoCommand = cli.Command{
 		if entry.MediaType == soci.SociIndexArtifactType {
 			return fmt.Errorf("the provided digest belongs to a SOCI index. Use `soci index info` to get the detailed information about it")
 		}
-		storage, err := oci.New(config.SociContentStorePath)
+		storage, err := oci.New(config.DefaultSociContentStorePath)
 		if err != nil {
 			return err
 		}

--- a/fs/config/config.go
+++ b/fs/config/config.go
@@ -40,13 +40,13 @@ package config
 
 const (
 	// Default path to OCI-compliant CAS
-	SociContentStorePath = "/var/lib/soci-snapshotter-grpc/content/"
+	DefaultSociContentStorePath = "/var/lib/soci-snapshotter-grpc/content/"
 
 	// Default path to local SOCI Index storage
-	SociIndexStorePath = "/var/lib/soci-snapshotter-grpc/indexes/"
+	DefaultSociIndexStorePath = "/var/lib/soci-snapshotter-grpc/indexes/"
 
 	// Default path to snapshotter root dir
-	SociSnapshotterRootPath = "/var/lib/soci-snapshotter-grpc/"
+	DefaultSociSnapshotterRootPath = "/var/lib/soci-snapshotter-grpc/"
 )
 
 type Config struct {
@@ -60,6 +60,10 @@ type Config struct {
 	NoPrometheus                   bool   `toml:"no_prometheus"`
 	MountTimeoutSec                int64  `toml:"mount_timeout_sec"`
 	FuseMetricsEmitWaitDurationSec int64  `toml:"fuse_metrics_emit_wait_duration_sec"`
+
+	RootPath         string `toml:"root_path"`
+	ContentStorePath string `toml:"content_store_path"`
+	IndexStorePath   string `toml:"index_store_path"`
 
 	// BlobConfig is config for layer blob management.
 	BlobConfig `toml:"blob"`

--- a/service/keychain/local_keychain/local_keychain.go
+++ b/service/keychain/local_keychain/local_keychain.go
@@ -118,7 +118,7 @@ func (kc *keychain) GetCredentials(host string, refspec reference.Spec) (string,
 	return "", "", nil
 }
 
-func Keychain(ctx context.Context, port int) *keychain {
+func Init(ctx context.Context, port int) *keychain {
 	lock.Lock()
 	defer lock.Unlock()
 	if singleton == nil {
@@ -135,7 +135,7 @@ func Get() (*keychain, error) {
 	lock.Lock()
 	defer lock.Unlock()
 	if singleton == nil {
-		return nil, fmt.Errorf("local keychain must be initialized (with Keychain()) before being gotten (with Get())")
+		return nil, fmt.Errorf("local keychain must be initialized (with Init()) before being gotten (with Get())")
 	}
 	return singleton, nil
 }

--- a/soci/artifacts.go
+++ b/soci/artifacts.go
@@ -89,7 +89,7 @@ var (
 
 // Get the default artifacts db path
 func ArtifactsDbPath() string {
-	return path.Join(config.SociSnapshotterRootPath, artifactsDbName)
+	return path.Join(config.DefaultSociSnapshotterRootPath, artifactsDbName)
 }
 
 // ArtifactEntry is a metadata object for a SOCI artifact.

--- a/store/fs.go
+++ b/store/fs.go
@@ -73,7 +73,7 @@ const (
 	fusermountBin = "fusermount"
 )
 
-func Mount(ctx context.Context, mountpoint string, layerManager *LayerManager, debug bool) error {
+func Mount(ctx context.Context, mountpoint string, layerManager *LayerManager, debug bool) (*fuse.Server, error) {
 	timeSec := time.Second
 	rawFS := fusefs.NewNodeFS(&rootnode{
 		fs: &fs{
@@ -99,10 +99,10 @@ func Mount(ctx context.Context, mountpoint string, layerManager *LayerManager, d
 	}
 	server, err := fuse.NewServer(rawFS, mountpoint, mountOpts)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	go server.Serve()
-	return server.WaitMount()
+	return server, server.WaitMount()
 }
 
 type fs struct {

--- a/store/manager.go
+++ b/store/manager.go
@@ -71,7 +71,10 @@ func NewLayerManager(ctx context.Context, root string, hosts source.RegistryHost
 	if maxConcurrency == 0 {
 		maxConcurrency = defaultMaxConcurrency
 	}
-	store, err := oci.New(config.SociContentStorePath)
+	if cfg.ContentStorePath == "" {
+		return nil, fmt.Errorf("config store path is empty")
+	}
+	store, err := oci.New(cfg.ContentStorePath)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create SOCI store: %w", err)
 	}


### PR DESCRIPTION
This PR makes a few changes so that the soci-store can be run in-process as a goroutine in the executor:
- Move local file paths to be passed via the `config` object rather than referenced directly.
- Move the `local_keychain` port flag specification into main (we can get rid of the grpc service after it's running in-process too).
- Makes the `Mount()` function return the fuse server so it can be unmounted directly on SIGINT.