### PR TITLE
Fix error check when fetching creds from local_keychain in artifact_fetcher

### DIFF
--- a/fs/artifact_fetcher.go
+++ b/fs/artifact_fetcher.go
@@ -82,7 +82,7 @@ func newRemoteStore(refspec reference.Spec) (*remote.Repository, error) {
 		Cache:  auth.DefaultCache,
 		Credential: func(ctx context.Context, host string) (auth.Credential, error) {
 			username, password, err := local_keychain.Keychain(ctx).GetCredentials(host, refspec)
-			if err != nil {
+			if err == nil {
 				return auth.Credential{
 					Username: username,
 					Password: password,


### PR DESCRIPTION
Vadim found a bug here that caused us to return creds when there is an error retrieving them from the local_keychain instead of when they're retrieved successfully from.