### PR TITLE
Add more logging for input/output bug

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,6 +61,9 @@ soci: proto
 soci-store: proto
 	cd cmd/ ; GO111MODULE=$(GO111MODULE_VALUE) go build -o $(OUTDIR)/$@ $(GO_BUILD_FLAGS) $(GO_LD_FLAGS) ./soci-store
 
+soci-store-race: proto
+	cd cmd/ ; GO111MODULE=$(GO111MODULE_VALUE) go build -race -o $(OUTDIR)/$@ $(GO_BUILD_FLAGS) $(GO_LD_FLAGS) ./soci-store
+
 proto:
 	protoc --go_out=. --go_opt=paths=source_relative --go-grpc_out=. --go-grpc_opt=paths=source_relative proto/local_keychain.proto
 

--- a/store/manager.go
+++ b/store/manager.go
@@ -179,6 +179,7 @@ func (r *LayerManager) getLayer(ctx context.Context, refspec reference.Spec, dgs
 		errChan    = make(chan error)
 	)
 	manifest, _, err := r.refPool.loadRef(ctx, refspec)
+	log.G(ctx).Debugf("fetched manifest with config digest %s for %s", manifest.Config.Digest.String(), refspec.String())
 	if err != nil {
 		return nil, fmt.Errorf("failed to get manifest and config: %w", err)
 	}
@@ -202,7 +203,7 @@ func (r *LayerManager) getLayer(ctx context.Context, refspec reference.Spec, dgs
 		for _, l := range manifest.Layers {
 			layers = append(layers, l.Digest.String())
 		}
-		return nil, fmt.Errorf("unknown digest %v for ref %q (known digests: [%s])", target, refspec.String(), strings.Join(layers, ","))
+		return nil, fmt.Errorf("unknown digest %s for ref %q (known digests: [%s])", dgst.String(), refspec.String(), strings.Join(layers, ","))
 	}
 	for _, l := range append([]ocispec.Descriptor{target}, preResolve...) {
 		l := l


### PR DESCRIPTION
It looks like we're getting requests for bad image-layer pairs, which suggests a race somewhere in store/fs.go. This PR adds a bit more logging and an option to build the store with -race which I plan to turn on in dev.
