### PR TITLE
Protect access to ents and entsCached in node.go with a mutex

### DIFF
--- a/fs/layer/node.go
+++ b/fs/layer/node.go
@@ -303,7 +303,9 @@ func (n *node) readdir() ([]fuse.DirEntry, syscall.Errno) {
 
 	n.entsMu.Lock()
 	if n.entsCached {
-		return n.ents, 0
+		ents := n.ents
+		n.entsMu.Unlock()
+		return ents, 0
 	}
 	n.entsMu.Unlock()
 
@@ -428,6 +430,7 @@ func (n *node) Lookup(ctx context.Context, name string, out *fuse.EntryOut) (*fu
 			}
 		}
 		if !found {
+			n.entsMu.Unlock()
 			return nil, syscall.ENOENT
 		}
 	}

--- a/fs/layer/node.go
+++ b/fs/layer/node.go
@@ -213,10 +213,9 @@ func newNode(layerDgst digest.Digest, r reader.Reader, blob remote.Blob, baseIno
 	}
 	ffs.s = ffs.newState(layerDgst, blob)
 	return &node{
-		id:     rootID,
-		attr:   rootAttr,
-		fs:     ffs,
-		entsMu: sync.Mutex{},
+		id:   rootID,
+		attr: rootAttr,
+		fs:   ffs,
 	}, nil
 }
 
@@ -463,10 +462,9 @@ func (n *node) Lookup(ctx context.Context, name string, out *fuse.EntryOut) (*fu
 		return nil, syscall.EIO
 	}
 	return n.NewInode(ctx, &node{
-		id:     id,
-		fs:     n.fs,
-		attr:   ce,
-		entsMu: sync.Mutex{},
+		id:   id,
+		fs:   n.fs,
+		attr: ce,
 	}, entryToAttr(ino, ce, &out.Attr)), 0
 }
 


### PR DESCRIPTION
Per [https://github.com/buildbuddy-io/buildbuddy-internal/issues/2570](https://github.com/buildbuddy-io/buildbuddy-internal/issues/2570) (and attached logs), there is a race condition in node.go that can cause it to mix up image directories, leading to input/output errors due to unprotected access to the ents field in `node`.

Logs: [datarace.txt](https://github.com/buildbuddy-io/soci-snapshotter/files/12589124/datarace.txt)